### PR TITLE
Feat : Added data types other than str and array - Closes #30

### DIFF
--- a/src/struct_strm/partial_parser.py
+++ b/src/struct_strm/partial_parser.py
@@ -1,6 +1,6 @@
 import tree_sitter_json as ts_json
 from tree_sitter import Language, Parser, Query, QueryCursor
-from struct_strm.tree_queries import get_queries, get_str_keys
+from struct_strm.tree_queries import get_queries, get_primitive_keys
 from struct_strm.llm_response_handler import openai_chunk_handler, ContinueSignal
 from typing import AsyncGenerator, Any, Union
 import logging
@@ -98,7 +98,7 @@ async def parse_query_matches_list_partial(
 
     results = []
     result_idx = -1
-    num_elements = await get_str_keys(nested_cls)
+    num_elements = await get_primitive_keys(nested_cls)
     num_elements = len(num_elements)
     group_num = 0
     # the problem is we are going to get a flat list here, should be in order by bytes?

--- a/src/struct_strm/tree_queries.py
+++ b/src/struct_strm/tree_queries.py
@@ -1,7 +1,6 @@
 from typing import Any, get_origin, get_args, Union
 from dataclasses import is_dataclass
 from struct_strm.compat import BaseModel, HAS_PYDANTIC, is_pydantic_model
-import inspect 
 
 
 import logging
@@ -38,7 +37,7 @@ _logger = logging.getLogger(__name__)
 # A set of supported primitive types
 PRIMITIVE_TYPES = {str, int, float, bool}
 
-async def get_primitive_keys(StreamedStruct: type[Any]) -> list[str]:
+async def get_str_keys(StreamedStruct: type[Any]) -> list[str]:
     l1_fields = []
     #Added as primitive dtypes 
 
@@ -136,7 +135,7 @@ async def get_array_keys(
             # get the key for the inner class (prob need to iterate for multiple keys)
             if inner_cls is None:
                 raise ValueError("nested classes must be structs")
-            inner_keys: list[str] = await get_primitive_keys(inner_cls)
+            inner_keys: list[str] = await get_str_keys(inner_cls)
             if isinstance(inner_cls, type) and (
                 is_pydantic_model(inner_cls) or is_dataclass(inner_cls)
             ):
@@ -147,7 +146,7 @@ async def get_array_keys(
 
 async def get_query_l1(StreamedStruct: type[Any]) -> str:
 
-    top_keys = await get_primitive_keys(StreamedStruct)
+    top_keys = await get_str_keys(StreamedStruct)
     top_keys_formatted = [f'"\\"{key}\\""' for key in top_keys]
     top_keys_str = " ".join(top_keys_formatted)
     query_str = f"""(
@@ -167,7 +166,7 @@ async def get_query_l2(
     # will revisit in the future, but I think that's all I need
     # return in format - {"struct_key_01": query_01, "struct_key_02": query_02}
     queries = {}
-    top_keys = await get_primitive_keys(StreamedStruct)
+    top_keys = await get_str_keys(StreamedStruct)
     filter_keys_str = ""
 
     if top_keys != []:
@@ -214,7 +213,7 @@ async def get_queries(
     # check l1 and l2 keys
 
     # if has no l1 keys then we can skip
-    has_l1_key = await get_primitive_keys(StreamedStruct) != []
+    has_l1_key = await get_str_keys(StreamedStruct) != []
     # need to check for nested structures
     has_l2_key = await has_nested_structure(StreamedStruct)
 

--- a/src/struct_strm/tree_queries.py
+++ b/src/struct_strm/tree_queries.py
@@ -9,6 +9,7 @@ _logger = logging.getLogger(__name__)
 # right now just going to focus on single and "two level" structs
 # note - nested structures must have different keys than parents
 
+#Orignal function commented ----- 
 
 # async def get_str_keys(StreamedStruct: type[Any]) -> list[str]:
 #     # right now only supporting string fields (no arrays, numbers will be "strings")
@@ -37,6 +38,8 @@ _logger = logging.getLogger(__name__)
 # A set of supported primitive types
 PRIMITIVE_TYPES = {str, int, float, bool}
 
+
+#I've updated this function to support the set of primitive dtypes
 async def get_str_keys(StreamedStruct: type[Any]) -> list[str]:
     l1_fields = []
     #Added as primitive dtypes 
@@ -149,6 +152,7 @@ async def get_query_l1(StreamedStruct: type[Any]) -> str:
     top_keys = await get_str_keys(StreamedStruct)
     top_keys_formatted = [f'"\\"{key}\\""' for key in top_keys]
     top_keys_str = " ".join(top_keys_formatted)
+    #replaced string->_value
     query_str = f"""(
         (pair
             key: (string) @key
@@ -180,6 +184,7 @@ async def get_query_l2(
         inner_keys_formatted = [f'"\\"{key}\\""' for key in inner_keys]
         inner_keys_str = " ".join(inner_keys_formatted)
         if group_by_object:
+            #replaced string->_value
             query_str = f"""(
             (object
                 (pair

--- a/tests/01_unit/test_tree_queries.py
+++ b/tests/01_unit/test_tree_queries.py
@@ -254,7 +254,7 @@ def test_get_queries_pydantic(product_pydantic_model):
         (#any-of? @key "\\"sku\\"")
     )) @obj
     """
-
+    #in this ive replaced string -> _value wrt the grammer 
     expected_query_str_l1 = f"""(
         (pair
             key: (string) @key
@@ -294,7 +294,7 @@ def test_get_l1_query_with_all_types(profile_with_all_types_pydantic):
     expected_query_str = f"""(
         (pair
             key: (string) @key
-            value: (_value) @value) 
+            value: (_value) @value)  
         (#any-of? @key "\\"name\\"" "\\"age\\"" "\\"is_active\\"" "\\"score\\"")
         )
     """

--- a/tests/01_unit/test_tree_queries.py
+++ b/tests/01_unit/test_tree_queries.py
@@ -55,6 +55,15 @@ def product_pydantic_model(item_pydantic_model):
 
     return Product
 
+@pytest.fixture
+def profile_with_all_types_pydantic():
+    class Profile(BaseModel):
+        name: str
+        age: int
+        is_active: bool
+        score: float
+        items: list[str] # This should be ignored by the primitive key search
+    return Profile
 
 def test_get_str_keys_dataclass(product_dataclass):
     Product = product_dataclass
@@ -259,3 +268,36 @@ def test_get_queries_pydantic(product_pydantic_model):
     assert l2_query["items"]["query_str"].replace(
         " ", ""
     ) == expected_query_str_l2.replace(" ", "")
+
+
+def test_get_primitive_keys_pydantic(profile_with_all_types_pydantic):
+    Profile = profile_with_all_types_pydantic
+    from struct_strm.tree_queries import get_primitive_keys 
+    
+    keys = asyncio.run(get_primitive_keys(Profile))
+    
+    # Assert that all primitive types are found
+    for key in ["name", "age", "is_active", "score"]:
+        assert key in keys
+        
+    # Assert that the list is NOT included
+    assert "items" not in keys
+
+
+# Add this function to the end of the file
+def test_get_l1_query_with_all_types(profile_with_all_types_pydantic):
+    Profile = profile_with_all_types_pydantic
+
+    l1_query = asyncio.run(get_query_l1(Profile))
+    
+    # Note the value is now (_value) instead of (string)
+    expected_query_str = f"""(
+        (pair
+            key: (string) @key
+            value: (_value) @value) 
+        (#any-of? @key "\\"name\\"" "\\"age\\"" "\\"is_active\\"" "\\"score\\"")
+        )
+    """
+    
+    # The .replace() helps ignore whitespace differences
+    assert l1_query.replace(" ", "").replace("\n", "") == expected_query_str.replace(" ", "").replace("\n", "")

--- a/tests/01_unit/test_tree_queries.py
+++ b/tests/01_unit/test_tree_queries.py
@@ -89,7 +89,7 @@ def test_get_l1_query_dataclass(product_dataclass):
     expected_query_str = f"""(
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#any-of? @key "\\"product_id\\"" "\\"name\\"" "\\"price\\"")
         )
     """
@@ -105,7 +105,7 @@ def test_get_l2_query_dataclass(product_dataclass):
         (object
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#not-eq? @key "\\"product_id\\"")
         (#not-eq? @key "\\"name\\"")
         (#not-eq? @key "\\"price\\"")
@@ -123,7 +123,7 @@ def test_get_l2_query_dataclass_ungrouped(product_dataclass):
     expected_query_str = """(
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#not-eq? @key "\\"product_id\\"")
         (#not-eq? @key "\\"name\\"")
         (#not-eq? @key "\\"price\\"")
@@ -141,7 +141,7 @@ def test_get_l1_query_pydantic(product_pydantic_model):
     expected_query_str = f"""(
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#any-of? @key "\\"product_id\\"" "\\"name\\"" "\\"price\\"")
         )
     """
@@ -156,7 +156,7 @@ def test_get_l2_query_pydantic(product_pydantic_model):
         (object
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#not-eq? @key "\\"product_id\\"")
         (#not-eq? @key "\\"name\\"")
         (#not-eq? @key "\\"price\\"")
@@ -174,7 +174,7 @@ def test_get_l2_query_pydantic_ungrouped(product_pydantic_model):
     expected_query_str = """(
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#not-eq? @key "\\"product_id\\"")
         (#not-eq? @key "\\"name\\"")
         (#not-eq? @key "\\"price\\"")
@@ -217,7 +217,7 @@ def test_get_queries_dataclass(product_dataclass):
     expected_query_str_l1 = f"""(
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#any-of? @key "\\"product_id\\"" "\\"name\\"" "\\"price\\"")
         )
     """
@@ -225,7 +225,7 @@ def test_get_queries_dataclass(product_dataclass):
         (object
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#not-eq? @key "\\"product_id\\"")
         (#not-eq? @key "\\"name\\"")
         (#not-eq? @key "\\"price\\"")
@@ -247,7 +247,7 @@ def test_get_queries_pydantic(product_pydantic_model):
         (object
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#not-eq? @key "\\"product_id\\"")
         (#not-eq? @key "\\"name\\"")
         (#not-eq? @key "\\"price\\"")
@@ -258,7 +258,7 @@ def test_get_queries_pydantic(product_pydantic_model):
     expected_query_str_l1 = f"""(
         (pair
             key: (string) @key
-            value: (string) @value)
+            value: (_value) @value)
         (#any-of? @key "\\"product_id\\"" "\\"name\\"" "\\"price\\"")
         )
     """
@@ -270,11 +270,11 @@ def test_get_queries_pydantic(product_pydantic_model):
     ) == expected_query_str_l2.replace(" ", "")
 
 
-def test_get_primitive_keys_pydantic(profile_with_all_types_pydantic):
+def test_replaced_str_keys_pydantic(profile_with_all_types_pydantic):
     Profile = profile_with_all_types_pydantic
-    from struct_strm.tree_queries import get_primitive_keys 
+    from struct_strm.tree_queries import get_str_keys
     
-    keys = asyncio.run(get_primitive_keys(Profile))
+    keys = asyncio.run(get_str_keys(Profile))
     
     # Assert that all primitive types are found
     for key in ["name", "age", "is_active", "score"]:

--- a/tests/01_unit/test_tree_queries.py
+++ b/tests/01_unit/test_tree_queries.py
@@ -1,6 +1,6 @@
 import asyncio
 from struct_strm.tree_queries import (
-    get_str_keys,
+    get_primitive_keys,
     get_query_l1,
     get_query_l2,
     get_queries,
@@ -65,17 +65,17 @@ def profile_with_all_types_pydantic():
         items: list[str] # This should be ignored by the primitive key search
     return Profile
 
-def test_get_str_keys_dataclass(product_dataclass):
+def test_get_primitive_keys_dataclass(product_dataclass):
     Product = product_dataclass
-    keys = asyncio.run(get_str_keys(Product))
+    keys = asyncio.run(get_primitive_keys(Product))
     for key in ["product_id", "name", "price"]:
         assert key in keys
     assert "items" not in keys
 
 
-def test_get_str_keys_pydantic(product_pydantic_model):
+def test_get_primitive_keys_pydantic(product_pydantic_model):
     Product = product_pydantic_model
-    keys = asyncio.run(get_str_keys(Product))
+    keys = asyncio.run(get_primitive_keys(Product))
     for key in ["product_id", "name", "price"]:
         assert key in keys
     assert "items" not in keys
@@ -272,9 +272,9 @@ def test_get_queries_pydantic(product_pydantic_model):
 
 def test_replaced_str_keys_pydantic(profile_with_all_types_pydantic):
     Profile = profile_with_all_types_pydantic
-    from struct_strm.tree_queries import get_str_keys
+    from struct_strm.tree_queries import get_primitive_keys
     
-    keys = asyncio.run(get_str_keys(Profile))
+    keys = asyncio.run(get_primitive_keys(Profile))
     
     # Assert that all primitive types are found
     for key in ["name", "age", "is_active", "score"]:

--- a/tests/01_unit/test_tree_sitter_parse.py
+++ b/tests/01_unit/test_tree_sitter_parse.py
@@ -133,12 +133,13 @@ async def test_parse_list_json_dataclass():
 async def test_parse_json_with_multiple_types():
     
     # 1. Define the model with multiple primitive types
+    # AFTER (This is the fix)
     class ProfileWithTypes(BaseModel):
-        name: str
-        age: int
-        is_active: bool
-        score: float
-        notes: str | None
+        name: str = ""
+        age: int = 0
+        is_active: bool = False
+        score: float = 0.0
+        notes: str | None = None
 
     # 2. Define a function to simulate the stream of JSON chunks
     async def simulate_stream():


### PR DESCRIPTION
This PR resolves issue #30 by expanding the streamer's capability to handle additional primitive Python data types beyond just strings and arrays.

### Key Changes:

-   The query generation logic in `tree_queries.py` has been updated to correctly identify `int`, `float`, and `bool` types in Pydantic and dataclass models.
-   The generated tree-sitter queries now use the generic `(_value)` node instead of the hardcoded `(string)` node, allowing the parser to correctly capture numbers, booleans, and nulls.

### Testing:

-   Added new unit tests to `test_tree_queries.py` to verify that the query generation logic is correct for the newly supported types.
-   Added a new end-to-end test to `test_tree_sitter_parse.py` that confirms a JSON stream containing `int`, `float`, `bool`, and `null` is parsed successfully into a Pydantic model.
-   All existing unit tests continue to pass, ensuring no regressions have been introduced.

Closes #30