### PR TITLE
Consistent naming for Pydantic and Dataclass Classes

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,10 +11,10 @@ from pydantic import BaseModel
 client = AsyncOpenAI(api_key="your token here")
 
 # Setup up all of the required info for the query
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: str = ""
 
-class DefaultListStruct(BaseModel):
+class PydanticDefaultListStruct(BaseModel):
     # mostly just for testing
     items: list[DefaultListItem] = []
 
@@ -181,7 +181,7 @@ async def test_hf_stream(
 
 
 # run the example
-class TestPerson(BaseModel):
+class PydanticTestPerson(BaseModel):
     name: str = ""
     age: str = ""
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,10 +17,10 @@ from struct_strm import parse_openai_stream
 prompt_context = ""
 user_query = "Create list describing 5 open source llm tools"
 
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: str = ""
 
-class DefaultListStruct(BaseModel):
+class PydanticDefaultListStruct(BaseModel):
     # mostly just for testing
     items: list[DefaultListItem] = []
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,11 +52,11 @@ from openai import AsyncOpenAI
 
 ...
 
-class DefaultFormItem(BaseModel):
+class PydanticDefaultFormItem(BaseModel):
     field_name: str = ""
     field_placeholder: str = ""
 
-class DefaultFormStruct(BaseModel):
+class PydanticDefaultFormStruct(BaseModel):
     form_fields: List[DefaultFormItem] = []
 
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -4,53 +4,53 @@ There are still many limiations for the parsing that I'm working to address. The
 ### 1. Only flat structs, or structs with up to one nextested level are supported  
 Suported:
 ```python
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: str = ""
 
 
-class DefaultListStruct(BaseModel):
+class PydanticDefaultListStruct(BaseModel):
     # mostly just for testing
     items: list[DefaultListItem] = []
 ```
 Not supported yet:  
 ```python
-class DefaultListItemDetail(BaseModel):
+class PydanticDefaultListItemDetail(BaseModel):
     detail: str = ""
 
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: DefaultListItemDetail = ""
 
-class DefaultListStruct(BaseModel):
+class PydanticDefaultListStruct(BaseModel):
     # mostly just for testing
     items: list[DefaultListItem] = []
 ```
 ### 2. I'm not handling any data types beyond strings and arrays (no ints/floats or optional types)  
 Suported:  
 ```python
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: str = ""
 ```
 Not supported yet:
 ```python
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: int = ""
 ```
 ### 3. Nested structures must have different value names  
 Suported:
 ```python
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: str = ""
 
-class DefaultListStruct(BaseModel):
+class PydanticDefaultListStruct(BaseModel):
     # mostly just for testing
     items: list[DefaultListItem] = []
 ```
 Not supported yet:
 ```python
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     items: str = ""
 
-class DefaultListStruct(BaseModel):
+class PydanticDefaultListStruct(BaseModel):
     # mostly just for testing
     items: list[DefaultListItem] = []
 ```

--- a/docs/parsing_streams.md
+++ b/docs/parsing_streams.md
@@ -10,11 +10,11 @@ The goal of the parsing is to always output fully constructed python structures.
 
 In the trivial case of a structured list, the structures may look like:
 ```python
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: str = ""
 
 
-class DefaultListStruct(BaseModel):
+class PydanticDefaultListStruct(BaseModel):
     # mostly just for testing
     items: list[DefaultListItem] = []
 ```

--- a/readme.md
+++ b/readme.md
@@ -61,11 +61,11 @@ from openai import AsyncOpenAI
 
 ...
 
-class DefaultFormItem(BaseModel):
+class PydanticDefaultFormItem(BaseModel):
     field_name: str = ""
     field_placeholder: str = ""
 
-class DefaultFormStruct(BaseModel):
+class PydanticDefaultFormStruct(BaseModel):
     form_fields: List[DefaultFormItem] = []
 
 

--- a/src/struct_strm/structs/form_structs.py
+++ b/src/struct_strm/structs/form_structs.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass, field
 from struct_strm.compat import to_json
 
 
-class DefaultFormItem(BaseModel):
+class PydanticDefaultFormItem(BaseModel):
     field_name: str = ""
     field_placeholder: str = ""
 
 
-class DefaultFormStruct(BaseModel):
+class PydanticDefaultFormStruct(BaseModel):
     # mostly just for testing
     form_fields: List[DefaultFormItem] = []
     # ex: form_fields=[{"field_name": "fruits", "field_placeholder": "apple orange"}, {"field_name": "appliance"}, {"item3": "mango pineapple"}]

--- a/src/struct_strm/structs/list_structs.py
+++ b/src/struct_strm/structs/list_structs.py
@@ -6,28 +6,28 @@ from dataclasses import dataclass, field
 from struct_strm.compat import to_json
 
 
-class DefaultListItem(BaseModel):
+class PydanticDefaultListItem(BaseModel):
     item: str = ""
 
 
-class DefaultListStruct(BaseModel):
+class PydanticDefaultListStruct(BaseModel):
     # mostly just for testing
     items: list[DefaultListItem] = []
     # ex: itesms=[{"item": "apple orange"}, {"item2": "banana kiwi grape"}, {"item3": "mango pineapple"}]
 
 
 @dataclass
-class DefaultListItemDC:
+class DataclassDefaultListItemDC:
     item: str = ""
 
 
 @dataclass
-class DefaultListStructDC:
+class DataclassDefaultListStructDC:
     items: list[DefaultListItemDC] = field(default_factory=lambda: [])
 
 
 @dataclass
-class DefaultListDataclass:
+class DataclassDefaultListDataclass:
     items: list[DefaultListItem] = field(default_factory=lambda: [])
 
 

--- a/src/struct_strm/structs/rubric_structs.py
+++ b/src/struct_strm/structs/rubric_structs.py
@@ -10,17 +10,17 @@ from struct_strm.compat import to_json
 # This is actually a 2 parter, since we need to do one generation after another - will need another approach
 
 
-class DefaultCriteria(BaseModel):
+class PydanticDefaultCriteria(BaseModel):
     # "Y"
     criteria_value: str = ""
 
 
-class DefaultCategory(BaseModel):
+class PydanticDefaultCategory(BaseModel):
     # "X"
     category_value: str = ""
 
 
-class DefaultOutlineRubric(BaseModel):
+class PydanticDefaultOutlineRubric(BaseModel):
     category: list[DefaultCategory] = []
     criteria: list[DefaultCriteria] = []
 
@@ -64,26 +64,26 @@ def create_rubric_enums(
         type=str,
     )
 
-    class ScopedRubricCell(BaseModel):
+    class PydanticScopedRubricCell(BaseModel):
         criteria: criteria_enum_cls
         category: category_enum_cls
         content: str
 
-    class ScopedDefaultRubric(BaseModel):
+    class PydanticScopedDefaultRubric(BaseModel):
         cells: list[ScopedRubricCell] = []
 
     return ScopedDefaultRubric
 
 
 # we don't need to restrict the response since it is alredy being restricted upstream
-class DefaultCell(BaseModel):
+class PydanticDefaultCell(BaseModel):
     # criteria and category must be enums
     category: str = ""
     criteria: str = ""
     content: str = ""
 
 
-class DefaultRubric(BaseModel):
+class PydanticDefaultRubric(BaseModel):
     cells: list[DefaultCell] = []
 
 

--- a/src/struct_strm/structs/table_structs.py
+++ b/src/struct_strm/structs/table_structs.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass, field
 from struct_strm.compat import to_json
 
 
-class ExampleRow(BaseModel):
+class PydanticExampleRow(BaseModel):
     title: str = ""
     genre: str = ""
     rating: str = ""
 
 
-class ExampleTableStruct(BaseModel):
+class PydanticExampleTableStruct(BaseModel):
     # mostly just for testing
     table: List[ExampleRow] = []
     # ex: table =  [

--- a/src/struct_strm/ui_components.py
+++ b/src/struct_strm/ui_components.py
@@ -29,7 +29,7 @@ _logger = logging.getLogger(__name__)
 
 
 @dataclass
-class AbstractComponent(ABC):
+class DataclassAbstractComponent(ABC):
     """
     Components may have 3 stages -
     1. pre llm response placeholder rendering
@@ -59,7 +59,7 @@ class AbstractComponent(ABC):
 
 
 @dataclass
-class ListComponent(AbstractComponent):
+class DataclassListComponent(AbstractComponent):
     # mostly just a simple example for testing
     items: List[str] = field(default_factory=list)
     # default_struct: ListStruct = field(default_factory=ListStruct)
@@ -114,7 +114,7 @@ class ListComponent(AbstractComponent):
 
 
 @dataclass
-class FormComponent(AbstractComponent):
+class DataclassFormComponent(AbstractComponent):
     form: List[Dict[str, str]] = field(default_factory=list)
     output: str = field(default="html")  # either output html or incremental json
 
@@ -167,7 +167,7 @@ class FormComponent(AbstractComponent):
 
 
 @dataclass
-class TableComponent(AbstractComponent):
+class DataclassTableComponent(AbstractComponent):
     table: List[Dict[str, str]] = field(default_factory=list)
     output: str = field(default="html")  # either output html or incremental json
 
@@ -226,7 +226,7 @@ class TableComponent(AbstractComponent):
 
 
 @dataclass
-class RubricComponent(AbstractComponent):
+class DataclassRubricComponent(AbstractComponent):
     rubric_keys: list[str] = field(default_factory=list)
     rubric_criteria: list[str] = field(default_factory=list)
     rubric_rows_outlined: list[tuple[str]] = field(default_factory=list)

--- a/tests/01_unit/test_tree_queries.py
+++ b/tests/01_unit/test_tree_queries.py
@@ -15,7 +15,7 @@ from typing import Any
 @pytest.fixture
 def item_dataclass():
     @dataclass
-    class Item:
+    class DataclassItem:
         sku: str = ""
 
     return Item
@@ -23,7 +23,7 @@ def item_dataclass():
 
 @pytest.fixture
 def item_pydantic_model():
-    class Item(BaseModel):
+    class PydanticItem(BaseModel):
         sku: str = ""
 
     return Item
@@ -34,7 +34,7 @@ def product_dataclass(item_dataclass):
     Item: type[Any] = item_dataclass
 
     @dataclass
-    class Product:
+    class DataclassProduct:
         product_id: str = ""
         name: str = ""
         price: str = ""
@@ -47,7 +47,7 @@ def product_dataclass(item_dataclass):
 def product_pydantic_model(item_pydantic_model):
     Item: BaseModel = item_pydantic_model
 
-    class Product(BaseModel):
+    class PydanticProduct(BaseModel):
         product_id: str = ""
         name: str = ""
         price: str = ""
@@ -57,7 +57,7 @@ def product_pydantic_model(item_pydantic_model):
 
 @pytest.fixture
 def profile_with_all_types_pydantic():
-    class Profile(BaseModel):
+    class PydanticProfile(BaseModel):
         name: str
         age: int
         is_active: bool

--- a/tests/01_unit/test_tree_sitter_parse.py
+++ b/tests/01_unit/test_tree_sitter_parse.py
@@ -106,11 +106,11 @@ async def test_parse_table_json_pydantic():
 @pytest.mark.asyncio
 async def test_parse_list_json_dataclass():
     @dataclass
-    class ListItem:
+    class DataclassListItem:
         item: str = ""
 
     @dataclass
-    class ListStruct:
+    class DataclassListStruct:
         items: list[ListItem] = field(default_factory=lambda: [])
 
     stream = simulate_stream_list_struct()
@@ -134,7 +134,7 @@ async def test_parse_json_with_multiple_types():
     
     # 1. Define the model with multiple primitive types
     # AFTER (This is the fix)
-    class ProfileWithTypes(BaseModel):
+    class PydanticProfileWithTypes(BaseModel):
         name: str = ""
         age: int = 0
         is_active: bool = False

--- a/tests/02_app/server.py
+++ b/tests/02_app/server.py
@@ -39,7 +39,7 @@ async def home(request: Request) -> HTMLResponse:
     return response
 
 
-class HealthCheck(BaseModel):
+class PydanticHealthCheck(BaseModel):
     status: str = "OK"
 
 

--- a/tests/local/hugging_face_example.py
+++ b/tests/local/hugging_face_example.py
@@ -92,7 +92,7 @@ async def test_hf_stream(
 
 if __name__ == "__main__":
     
-    class TestPerson(BaseModel):
+    class PydanticTestPerson(BaseModel):
         name: str = ""
         age: str = ""
 


### PR DESCRIPTION
 Renamed all BaseModel classes to Pydantic[ClassName] dataclass models to Dataclass[ClassName] for consistency