### PR TITLE
fix: Make Playwright test for SSE stream more robust - Closes #36

### DIFF
--- a/tests/02_app/test_browser.py
+++ b/tests/02_app/test_browser.py
@@ -19,14 +19,17 @@ def test_simple_list_stream(page: Page, get_page):
     button = page.locator("#test-stream-list-btn")
     expect(button).to_be_visible(timeout=5000)
     expect(button).to_be_enabled()
-    button.click(timeout=2000)
 
-    # Wait for HTMX to inject the SSE container
-    page.wait_for_selector("#sse-list-container", state="attached", timeout=5000)
+    # It waits for the real data stream connection.
+    with page.expect_response("**/test_list/**", timeout=15000) as response_info:
+        button.click(timeout=2000)
 
-    # the server response (htmx)
-    expect(page.locator("#list-card").first).to_be_visible(timeout=10000)
-    expect(page.locator("li")).to_have_count(3, timeout=10000)
+    response = response_info.value
+    assert response.ok
+
+    # The rest of the test
+    expect(page.locator("#list-card").first).to_be_visible(timeout=5000)
+    expect(page.locator("li")).to_have_count(3, timeout=5000)
 
 
 def test_simple_form_stream(page: Page, get_page):


### PR DESCRIPTION
This PR resolves the flaky test issue #36 by improving how the Playwright browser test handles asynchronous UI updates from Server-Sent Events (SSE).

Instead of relying on a fixed-timeout `wait_for_selector`, the test has been updated to use `page.expect_response()`.

-   The test now explicitly waits for the network response from the `/test_list` SSE stream endpoint.
-   This synchronizes the test with the application's actual network activity, ensuring it only proceeds to check the UI *after* the server has started sending data.

Closes #36