### PR TITLE
fix: clearer error when struct lacks default values

### DIFF
--- a/src/struct_strm/partial_parser.py
+++ b/src/struct_strm/partial_parser.py
@@ -176,7 +176,15 @@ async def tree_sitter_parse(
     source: Union[str, None] = None,
 ) -> AsyncGenerator[Union[type[Any], dict], None]:
     # return an instance of the struct for every response
-    response = struct()
+    try:
+        response = struct()
+    except TypeError as e:
+        raise TypeError(
+            f"Could not instantiate {struct.__name__} with no arguments: {e}. "
+            "All fields on the provided struct must have default values "
+            "(e.g. `field_name: str = \"\"` or `field_name: list = field(default_factory=list)`) "
+            "so that partial results can be constructed as the stream is parsed."
+        ) from e
     buffer = ""
     JSON_LANG = Language(ts_json.language())
     parser = Parser(JSON_LANG)


### PR DESCRIPTION
## Summary
- Resolves #46.
- The opaque `TypeError: ExampleStruct.__init__() missing 1 required positional argument: 'message'` raised when a user supplied a struct/dataclass without default values is now caught and re-raised with an actionable message explaining that all fields must have defaults so partial responses can be constructed.

## Changes
- `src/struct_strm/partial_parser.py`: wrap the initial `struct()` instantiation in `tree_sitter_parse` with a `try/except TypeError` that re-raises a descriptive `TypeError` (chained via `raise ... from e`) suggesting default values for fields.

## Testing
- `python -m pytest tests/01_unit` — 48 passed (same as baseline).
